### PR TITLE
Add docker container used for patch tester for Joomla4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM alpine:edge
+RUN apk --no-cache add \
+        libressl \
+        lftp \
+        bash \
+        diffutils \
+        git \
+        openssh-client \
+        zip
+ADD compare.sh .
+RUN chmod +x ./compare.sh
+
+ENTRYPOINT ./compare.sh

--- a/README.MD
+++ b/README.MD
@@ -1,3 +1,30 @@
-# Docker Images for Joomla CI
+# Docker Container for Patch Tester (Joomla! 4)
 
-This repo contains several images for Joomla development.
+Docker Container for zip'ing the diff between the Pull Request's branch and the reference branch (e.g. `4.0-dev`). 
+
+### Script steps
+
+1. Update the reference repo. You can set the branch of the repo with `BRANCH_NAME` environmental variable. In this step, the reference repo will be cloned (if it not exists) and update itself to the latest commit. This repo is in a mounted directory so it will stay for the next build aswell. The reference repo's folder should be mounted in `CMP_MASTER_FOLDER` environmental variable.
+
+1. Create the diff between the local repo and the reference repo. A list of all created, changed/differing and deleted files gets created. All the files that were created or modified get packet into a zip file with the name `build` environmental variable. The deleted files are noted in `deleted-files.log`.
+
+1. Last but not least, the zip file and deleted file list is uploaded to the CI server.
+
+### List of environmental variables
+
+| Variable           | Mandatory | Description                                                                         |
+|--------------------|-----------|-------------------------------------------------------------------------------------|
+| CMP_ARCHIVE_NAME   | No        | The name of the zip file                                                            |
+| CMP_MASTER_FOLDER  | Yes       | The directory path of the reference repository                                      |
+| CMP_SLAVE_FOLDER   | Yes       | The directory path of the current repository                                        |
+| BRANCH_NAME        | Yes       | The branch name of the reference repository                                         |
+| DRONE_PULL_REQUEST | Yes       | The Pull Request ID                                                                 |
+| FTP_HOSTNAME       | Yes       | The host name (including port) where the files get uploaded (e.g. ci.joomla.org:21) |
+| FTP_USERNAME       | Yes       | The username to connect to the CI server                                            |
+| FTP_PASSWORD       | Yes       | The password to connect to the CI server                                            |
+| FTP_SECURE         | No        | Allow and enforce SSL decryption (SFTP)                                             |
+| FTP_VERIFY         | No        | Verify certificate and check hostname                                               |
+| FTP_DEST_DIR       | No        | Destination directory on CI server (where files get uploaded)                       |
+| FTP_SRC_DIR        | No        | The source directory where files are uploaded from                                  |
+| FTP_CHMOD          | No        | Disallow file permissions on remote server                                          |
+| FTP_CLEAN_DIR      | No        | Clean remote directory before deploying new files                                   |

--- a/compare.sh
+++ b/compare.sh
@@ -209,12 +209,6 @@ for i in "${in_arr[@]}"; do
     FTP_INCLUDE_STRING="$FTP_INCLUDE_STRING -x $i"
 done
 
-echo "Opening lftp connection with parameters:"
-echo "FTP Username: " $FTP_USERNAME
-echo "FTP Password: " $FTP_PASSWORD
-echo "FTP Hostname: " $FTP_HOSTNAME
-echo "FTP Destination directory: " $FTP_DEST_DIR"/"$DRONE_PULL_REQUEST
-
 lftp -u $FTP_USERNAME,$FTP_PASSWORD $FTP_HOSTNAME << EOF
 set ftp:ssl-allow $FTP_SECURE
 set ftp:ssl-force $FTP_SECURE

--- a/compare.sh
+++ b/compare.sh
@@ -1,0 +1,268 @@
+#!/bin/bash
+
+##########
+# UPDATE #
+##########
+
+echo "#################################################"
+echo "Updating Joomla! 4.0-dev reference (if necassary)"
+echo "#################################################"
+
+echo "Current directory: "$(pwd)
+
+current_directory=$(pwd)
+
+if ! [ -d $CMP_MASTER_FOLDER ]; then
+    # Reference cache not mounted
+    echo "Reference cache not mounted"
+    # exit 1
+    mkdir $CMP_MASTER_FOLDER # DEBUG ONLY
+fi
+
+cd $CMP_MASTER_FOLDER
+echo "Current directory: "$(pwd)
+
+if ! [ -d .git ]; then
+    # Directory is not a git repository
+    echo "Git repository not cloned"
+    git clone https://github.com/joomla/joomla-cms.git .
+fi
+
+git checkout $BRANCH_NAME
+git pull
+
+cd current_directory
+echo "Current directory: "$(pwd)
+
+########
+# DIFF #
+########
+
+echo "##################################"
+echo "Creating diff between repositories"
+echo "##################################"
+echo "Current directory: "$(pwd)
+
+# Check if archive name is set
+if [ -z "$CMP_ARCHIVE" ]; then
+    echo "Build Archive name hasn't been set"
+    CMP_ARCHIVE="build"
+fi
+
+# Check if master repository folder is set
+if [ -z "$CMP_MASTER_FOLDER" ]; then
+    echo "Master folder hasn't been set"
+    CMP_MASTER_FOLDER="../joomla-cms"
+fi
+
+# Check if master repository folder is set
+if [ -z "$CMP_SLAVE_FOLDER" ]; then
+    echo "Slave folder hasn't been set"
+    $CMP_SLAVE_FOLDER="$(pwd)/../joomla4"
+fi
+
+# Declare variables (can be set from outside)
+CMP_TMP="tmp"
+CMP_MASTER_DIR="$CMP_TMP/master"
+CMP_SLAVE_DIR="$CMP_TMP/slave"
+CMP_BUILD_DIR="$CMP_TMP/build"
+CMP_DIFF_LOG="$CMP_TMP/diff.log"
+CMP_ONLY_IN_MASTER_LOG="deleted_files.log"
+CMP_ONLY_IN_SLAVE_LOG="$CMP_TMP/only_in_slave.log"
+CMP_DIFFERS_FROM_LOG="$CMP_TMP/differs_from.log"
+
+# Remove existent temp directory
+rm -rf $CMP_TMP
+
+# Create temp directories
+mkdir $CMP_TMP
+mkdir $CMP_MASTER_DIR
+mkdir $CMP_SLAVE_DIR
+
+# Compare files/directories
+echo "Finding differences between builds..."
+echo "MASTER: " $CMP_MASTER_FOLDER
+echo "SLAVE:  " $CMP_SLAVE_FOLDER
+	diff -qr --exclude=node_modules \
+             --exclude=build \
+             --exclude=administrator/components/com_media/node_modules \
+             --exclude=.* \
+             --exclude=configuration.php \
+        $CMP_MASTER_FOLDER $CMP_SLAVE_FOLDER >> $CMP_DIFF_LOG
+
+# Create list of files that only exist in master directory
+cat $CMP_DIFF_LOG | grep -E "^Only in "$CMP_MASTER_FOLDER"*" | sed -n 's/://p' | awk '{print $3"/"$4}' >> $CMP_ONLY_IN_MASTER_LOG
+
+# Create list of files that only exist in slave directory
+cat $CMP_DIFF_LOG | grep -E "^Only in "$CMP_SLAVE_FOLDER"*" | sed -n 's/://p' | awk '{print $3"/"$4}' >> $CMP_ONLY_IN_SLAVE_LOG
+
+# Create list of files that differ from master
+cat $CMP_DIFF_LOG | grep -Eo " and tmp\/slave\/[^[:space:]]+" | grep -Eo "tmp\/slave\/[^[:space:]]+" >> $CMP_DIFFERS_FROM_LOG
+
+echo "Finished finding differences between builds."
+
+# Create build folder
+mkdir $CMP_BUILD_DIR
+
+# Copy all files that only occur in slave into build folder
+while IFS="" read -r file || [ -n "$file" ]
+do
+    destination_file="$CMP_BUILD_DIR/$(echo $file  | cut -d'/' -f3-)"
+    echo "Copying file " $destination_file "..."
+    mkdir -p $destination_file && cp -r $file $destination_file
+done < $CMP_ONLY_IN_SLAVE_LOG
+
+# Copy all files that differ into build folder
+while IFS="" read -r file || [ -n "$file" ]
+do
+    destination_file="$CMP_BUILD_DIR/$(echo $file  | cut -d'/' -f3-)"
+    echo "Copying file " $destination_file "..."
+    mkdir -p $destination_file && cp -r $file $destination_file
+done < $CMP_DIFFERS_FROM_LOG
+
+# Zip build folder
+echo "Zipping build folder..."
+pushd $CMP_BUILD_DIR
+zip -qr $CMP_ARCHIVE *
+popd
+# Move files to upload directory
+mkdir upload
+mv "$CMP_BUILD_DIR/$CMP_ARCHIVE.zip" ./upload
+mv "$CMP_ONLY_IN_MASTER_LOG" ./upload
+echo "Finished zipping build."
+
+# Clean up temporary files
+rm -rf $CMP_TMP
+
+##########
+# UPLOAD #
+##########
+
+echo "###########################"
+echo "Uploading diff to CI server"
+echo "###########################"
+echo "Current directory: "$(pwd)
+
+# Check if FTP username is set
+if [ -z "$FTP_USERNAME" ]; then
+    echo "FTP-username not set"
+    exit 1
+fi
+
+# Check if FTP hostname is set
+if [ -z "$FTP_HOSTNAME" ]; then
+    echo "FTP-hostname not set"
+    exit 1
+fi
+
+# Check if FTP password is set
+if [ -z "$FTP_PASSWORD" ]; then
+    echo "FTP-password not set"
+    exit 1
+fi
+
+# Allow and enforce SSL decryption
+if [ -z "$FTP_SECURE" ]; then
+    FTP_SECURE="true"
+else
+    FTP_SECURE="false"
+fi
+
+# Verify certificate and check hostname
+if [ -z "$FTP_VERIFY" ]; then
+    FTP_VERIFY="true"
+fi
+
+# Destination directory on remote server
+if [ -z "$FTP_DEST_DIR" ]; then
+    FTP_DEST_DIR="/"
+fi
+
+# Source directory on local machine
+if [ -z "$FTP_SRC_DIR" ]; then
+    FTP_SRC_DIR="/"
+fi
+
+# Disallow file permissions
+if [ "$FTP_CHMOD" = false ]; then
+    FTP_CHMOD="-p"
+else
+    FTP_CHMOD=""
+fi
+
+# Clean remote directory before deploy
+if [ "$FTP_CLEAN_DIR" = true ]; then
+    FTP_CLEAN_DIR="rm -r $FTP_DEST_DIR"/"$DRONE_PULL_REQUEST"
+else
+    FTP_CLEAN_DIR=""
+fi
+
+FTP_EXCLUDE_STRING=""
+FTP_INCLUDE_STRING="./upload"
+
+IFS=',' read -ra in_arr <<< "$FTP_EXCLUDE"
+for i in "${in_arr[@]}"; do
+    FTP_EXCLUDE_STRING="$FTP_EXCLUDE_STRING -x $i"
+done
+IFS=',' read -ra in_arr <<< "$FTP_INCLUDE"
+for i in "${in_arr[@]}"; do
+    FTP_INCLUDE_STRING="$FTP_INCLUDE_STRING -x $i"
+done
+
+echo "Opening lftp connection with parameters:"
+echo "FTP Username: " $FTP_USERNAME
+echo "FTP Password: " $FTP_PASSWORD
+echo "FTP Hostname: " $FTP_HOSTNAME
+echo "FTP Destination directory: " $FTP_DEST_DIR"/"$DRONE_PULL_REQUEST
+
+lftp -u $FTP_USERNAME,$FTP_PASSWORD $FTP_HOSTNAME << EOF
+set ftp:ssl-allow $FTP_SECURE
+set ftp:ssl-force $FTP_SECURE
+set ftp:ssl-protect-data $FTP_SECURE
+set ssl:verify-certificate $FTP_VERIFY
+set ssl:check-hostname $FTP_VERIFY
+$FTP_CLEAN_DIR
+mirror --verbose $FTP_CHMOD -R $FTP_INCLUDE_STRING $FTP_EXCLUDE_STRING -R $FTP_DEST_DIR"/"$DRONE_PULL_REQUEST
+wait all
+exit
+EOF
+
+rm -rf ./upload
+
+echo ""
+echo ""
+echo ""
+
+echo "                             Bye, have a great time!                            "
+
+echo ""
+echo ""
+echo ""
+echo "...................................................................       ..'',,"
+echo ".........................................'''...............'.........       ..''"
+echo "........................................'',;,''''....''',,;:::;;,.....       ';,"
+echo "........................................';oxddodlccclllclloooollc;'....      .',"
+echo ".... .. ...............................,:lxkkkkkkkkOOOOkxxxdddool:,'...       .'"
+echo "..  ..  ........,cl:,....''............:odxxkkkkkxkkOOOkkxxddoollc;,...        ."
+echo ".   ............,oxdo:'...............;oddxxxxxxxxkkkkkxxdddooollc:,'..        ."
+echo "    .............lxddl,..............':ccclodxxkkxxkkkkxxxxddoollc:;'..        ."
+echo "     ....  .....;oddo:..............,:c::;;;:codxxddlc:::clloolllcc;'..       .."
+echo "      ... ....'cxxddo:'............:ool:;;::;:coxdolc:::;;::ccllllc:,...   . ..."
+echo ".     .......;oxxxxxddooolc;.......cxddoooolllodxdollc:::;;;:lllllcc;,...';;,..."
+echo "...........'cddddxxddooodddol:'....:xxkkkkxxdddddooooododddoooooolcc:,,',cccc;.."
+echo "..........,ldddddddooooooooool;.  .:dxxxxxdodxdoloooddxxxxkxddoolcc:;:c:coool;.."
+echo ".........:odddddddollloooolllc'....;odooooolccc::cccloodxxxddoolcc:::clodddo:'.."
+echo ".......;ldddddddddddooooooolll;.. .:oollooooolcccllllllloooollllcc:::cldddo:'..."
+echo ".....;lddddddddddddoollolllcc:'....:odolcc:looooollcccccllllllllc::::cool;'....."
+echo "...,lddddddddddddddoolllllc:;'.....,oddooolloddddolc::::cllllllc::;;,....  .    "
+echo "..;loddddddddddddddolllllcc:;'......;ldddoolclooolcccllolllcccc:;,''..     .    "
+echo ".,cooddddddoooooolllllllcc:'..... ...'coooollllllollllooolc::;,''....           "
+echo ".,coddddoooollllcllllcc:;,.. ..       .;clollllllllllllcc::;,'...''..'.     .   "
+echo " .coooollcc::::;;;;,'..... ......      ..':llooooollc::;,,'''''',,,,;c'      .. "
+echo " ..';ccc:;'......  ...   ........         ..',,,,,,,'''''.'',,;;;;,:l;.       .."
+echo "     ......        .............               ........'',,;;::::lod:.         ."
+echo "....            . ..........   .                ..''',,;;:::ccclxOkc.           "
+
+echo ""
+echo ""
+echo ""

--- a/compare.sh
+++ b/compare.sh
@@ -81,8 +81,6 @@ mkdir $CMP_SLAVE_DIR
 
 # Compare files/directories
 echo "Finding differences between builds..."
-echo "MASTER: " $CMP_MASTER_FOLDER
-echo "SLAVE:  " $CMP_SLAVE_FOLDER
 	diff -qr --exclude=node_modules \
              --exclude=build \
              --exclude=administrator/components/com_media/node_modules \


### PR DESCRIPTION
Add docker container used for patch tester for Joomla 4.

Use this configuration step in joomla/joomla-cms > `.drone.yml` to get started.

```
  - name: publish-diff
    image: # TODO Change to docker hub address of new image
    depends_on: [ npm ]
    commands:
      - export PULL_ID=$DRONE_PULL_REQUEST
    environment:
      CMP_ARCHIVE_NAME: "build"
      CMP_MASTER_FOLDER: "/reference"
      CMP_SLAVE_FOLDER: "." # The directory the current repo is in
      FTP_USERNAME:
        from_secret: ftpusername
      FTP_PASSWORD:
        from_secret: ftppassword
      FTP_HOSTNAME: # TODO Change to CI server of Joomla!
      FTP_DEST_DIR: /patchtester
      FTP_VERIFY: "false" # TODO Change to CI server of Joomla!
      FTP_SECURE: "false" # TODO Change to CI server of Joomla!
      BRANCH_NAME: "4.0-dev" # Current branch to check against (from repo joomla/joomla-cms)
      DRONE_PULL_REQUEST: DRONE_PULL_REQUEST
    volumes:
      - name: reference
        path: /reference
```