### PR TITLE
selenium-standalone in the docker-image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN DEBIAN_FRONTEND='noninteractive' apt-get install -y mariadb-server libqtgui4
     php7.2-cli php7.2-curl php7.2-gd php7.2-mysql php7.2-zip php7.2-xml php7.2-ldap php7.2-mbstring libapache2-mod-php7.2 \
     php7.2-pgsql curl wget firefox unzip git fluxbox libxss1 libappindicator3-1 libindicator7 openjdk-8-jre xvfb \
     gconf-service fonts-liberation dbus xdg-utils libasound2 libqt4-dbus libqt4-network libqtcore4 libpython2.7 \
-    libqt4-xml libaudio2 fontconfig nodejs npm
+    libqt4-xml libaudio2 fontconfig nodejs npm netcat
 
 # Install npx which is required to trigger our JS testsuite
 RUN npm install -g npx

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,5 +40,8 @@ RUN dpkg -i google-chrome*.deb
 
 RUN apt-get upgrade -y
 
+RUN npm install -g selenium-standalone
+RUN selenium-standalone install
+
 # Start Apache and MySQL
 CMD apache2ctl -D FOREGROUND


### PR DESCRIPTION
Have selenium install in the docker image, this way you don't need to install it (with a absurd long version string), every time you run the system tests.