### PR TITLE
Chore - Add XDebug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,13 @@ RUN cd /usr/local/bin \
 	&& wget -O phpunit --no-check-certificate https://phar.phpunit.de/phpunit-4.8.36.phar \
 	&& chmod +x phpunit
 
-RUN pecl channel-update pecl.php.net && pecl install redis-4.3.0
-RUN echo extension=redis.so > /etc/php5/conf.d/redis.ini
+RUN pecl channel-update pecl.php.net && \
+	pecl install redis-4.3.0 && \
+	echo extension=redis.so > /etc/php5/conf.d/redis.ini && \
+	echo extension=redis.so > /etc/php5/cli/conf.d/redis.ini
+RUN pecl install -n xdebug-2.2.7 && \
+	echo 'zend_extension='`find /usr -name xdebug.so`'\nxdebug.coverage_enable=on\n' > /etc/php5/conf.d/xdebug.ini && \
+	echo 'zend_extension='`find /usr -name xdebug.so`'\nxdebug.coverage_enable=on\n' > /etc/php5/cli/conf.d/xdebug.ini
 
 COPY apache_default /etc/apache2/sites-available/default
 COPY run /usr/local/bin/run

--- a/README.MD
+++ b/README.MD
@@ -1,3 +1,4 @@
 # Joomla Docker Image for PHP 5.3
 
-This is a Docker image for the Joomla CI with PHP 5.3. The image is based on a Dockerfile from Alexander Schenkel <alex@alexi.ch>
+This is a Docker image for the Joomla CI with PHP 5.3 and XDebug 2.2.7.
+The image is based on a Dockerfile from Alexander Schenkel <alex@alexi.ch>


### PR DESCRIPTION
### Summary of Changes

Add XDebug to the installation

### Testing Instructions

1. Build the image
    `docker build --tag testimage .`
    
2. Start a container from that image
    `docker run -it -p 80:80 --rm --name testcontainer testimage bash`

3. Check the PHP version
    `php -v`
    
    You should see the PHP version and the XDebug version stated in the `README.md` file

### Documentation Changes Required

`README.md` is changed accordingly.

