### PR TITLE
Chore - Add XDebug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,3 +41,6 @@ ENV COMPOSER_CACHE_DIR="/tmp/composer-cache"
 RUN cd /usr/local/bin \
 	&& wget -O phpunit --no-check-certificate https://phar.phpunit.de/phpunit-4.8.36.phar \
 	&& chmod +x phpunit
+
+RUN pecl install -n xdebug-2.4.1 \
+	&& echo 'zend_extension='`find /usr -name xdebug.so`'\nxdebug.coverage_enable=on\n' > /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini

--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
-# Docker Container with PHP 5.4
+# Docker Container with PHP 5.4 and XDebug
 
 # ATTENTION! We strongly suggest to NOT use this Docker image!
 It is horribly outdated and we are keeping it only to ensure out compatibility claims. PHP 5.4 has been EOL since September 2015.
 
-Docker Container for unit testing with PHP 5.4 and our PHP Unit extensions.
+This is a Docker image for the Joomla CI with PHP 5.4 and XDebug 2.4.7. 


### PR DESCRIPTION
### Summary of Changes

Add XDebug to the installation

### Testing Instructions

1. Build the image
    `docker build --tag testimage .`
    
2. Start a container from that image
    `docker run -it -p 80:80 --rm --name testcontainer testimage bash`

3. Check the PHP version
    `php -v`
    
    You should see the PHP version and the XDebug version stated in the `README.md` file

### Documentation Changes Required

`README.md` is changed accordingly.
