### PR TITLE
Chore - Add XDebug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,14 +32,15 @@ RUN pecl install apcu \
 RUN sed -i 's/memory_limit\s*=.*/memory_limit=-1/g' /usr/local/etc/php/php.ini-production \
 	&& sed -i 's/memory_limit\s*=.*/memory_limit=-1/g' /usr/local/etc/php/php.ini-development
 
-#RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
 # We would love to check the signature of the installer, but since the signature changes very frequently, we can't really commit it to the repository
 #	&& php -r "if (hash_file('sha384', 'composer-setup.php') === 'e5325b19b381bfd88ce90a5ddb7823406b2a38cff6bb704b0acc289a09c8128d4a8ce2bbafcd1fcbdc38666422fe2806') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
-#	&& php composer-setup.php \
-#	&& php -r "unlink('composer-setup.php');" \
-#	&& mv composer.phar /usr/local/bin/composer
+	&& php composer-setup.php \
+	&& php -r "unlink('composer-setup.php');" \
+	&& mv composer.phar /usr/local/bin/composer2 \
+	&& chmod +x /usr/local/bin/composer2
 
-# Fallback to composer 1 untill our dependencies are fixed
+# Fallback to composer 1 until our dependencies are fixed
 RUN php -r "readfile('https://getcomposer.org/composer-1.phar');" > /usr/local/bin/composer \
 	&& chmod +x /usr/local/bin/composer
 
@@ -48,3 +49,9 @@ ENV COMPOSER_CACHE_DIR="/tmp/composer-cache"
 RUN cd /usr/local/bin \
 	&& wget -O phpunit --no-check-certificate https://phar.phpunit.de/phpunit-8.5.8.phar \
 	&& chmod +x phpunit
+
+RUN cd /usr/local/etc/php \
+	&& cp php.ini-development php.ini
+
+RUN pecl install xdebug-3.0.2 \
+	&& echo 'zend_extension='`find /usr -name xdebug.so`'\nxdebug.mode=develop,coverage\n' > /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini

--- a/README.MD
+++ b/README.MD
@@ -1,3 +1,8 @@
-# Docker Container with PHP 7.2
+# Docker Container with PHP 7.3
 
-Docker Container for unit testing with PHP 7.2 and our PHP Unit extensions.
+Docker Container for unit testing with PHP 7.3, XDebug 3.0.2 and our PHP Unit extensions.
+
+Some of our dependencies still rely on Composer 1.x, so that version is installed as
+a default for Composer.
+If you want to check, whether the dependencies work with Composer 2.0,
+use the command `composer2` instead of `composer`.


### PR DESCRIPTION
### Summary of Changes

Add XDebug to the installation.
Provide Composer 2.0 as `composer2`.

### Testing Instructions

1. Build the image
    `docker build --tag testimage .`
    
2. Start a container from that image
    `docker run -it -p 80:80 --rm --name testcontainer testimage bash`

3. Check the PHP version
    `php -v`
    
    You should see the PHP version and the XDebug version stated in the `README.md` file

### Documentation Changes Required

`README.md` is changed accordingly.
