### PR TITLE
Chore - Add XDebug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,3 +50,9 @@ RUN cd /usr/local/bin \
 RUN cd /usr/local/bin \
 	&& wget -O phploc --no-check-certificate https://phar.phpunit.de/phploc.phar \
 	&& chmod +x phploc
+
+RUN cd /usr/local/etc/php \
+	&& cp php.ini-development php.ini
+
+RUN pecl install xdebug-3.0.2 \
+	&& echo 'zend_extension='`find /usr -name xdebug.so`'\nxdebug.mode=develop,coverage\n' > /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini

--- a/README.MD
+++ b/README.MD
@@ -1,3 +1,3 @@
-# Docker Images for Joomla CI
+# Docker Container with PHP 7.4
 
-This repo contains several images for Joomla development.
+Docker Container for unit testing with PHP 7.4, XDebug 3.0.2 and our PHP Unit extensions.


### PR DESCRIPTION
### Summary of Changes

Add XDebug to the installation

### Testing Instructions

1. Build the image
    `docker build --tag testimage .`
    
2. Start a container from that image
    `docker run -it -p 80:80 --rm --name testcontainer testimage bash`

3. Check the PHP version
    `php -v`
    
    You should see the PHP version and the XDebug version stated in the `README.md` file

### Documentation Changes Required

`README.md` is changed accordingly.
