### PR TITLE
Update env.example

### DIFF
--- a/env.example
+++ b/env.example
@@ -13,7 +13,7 @@ KEY_ADAPTER=local
 KEY_ADAPTER=keepass
 KEY_ADAPTER_KEEPASS_DATABASE_PATH="The path to the .kdbx file"
 KEY_ADAPTER_KEEPASS_ADDITIONAL="--key-file <optional path to an key file if used by keepassxc database>"
-; each entry must have a corresponding attachment called root.json targets.json snapshot.json timestamp.json depending on the key
+# each entry must have a corresponding attachment called root.json targets.json snapshot.json timestamp.json depending on the key
 KEY_ADAPTER_KEEPASS_ROOT_KEY="Search string for the root key entry ex. '/Joomla/Root Key', starting with Keepass 2.8 this could be UUID:<entryuuid>"
 KEY_ADAPTER_KEEPASS_TARGETS_KEY="Search string for the targets key entry ex. '/Joomla/Targets Key', starting with Keepass 2.8 this could be UUID:<entryuuid>"
 KEY_ADAPTER_KEEPASS_SNAPSHOT_KEY="Search string for the snapshot key entry ex. '/Joomla/Snapshot Key', starting with Keepass 2.8 this could be UUID:<entryuuid>"


### PR DESCRIPTION
Fixes issue with:
$ bash build.sh
.env: line 16: syntax error near unexpected token `;' .env: line 16: `; each entry must have a corresponding attachment called root.json targets.json snapshot.json timestamp.json depending on the key'