### PR TITLE
node 20 for cypress 13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN DEBIAN_FRONTEND='noninteractive' apt-get install -y mariadb-server libqtgui4
     libqt4-xml libaudio2 libgbm1 fontconfig netcat rsync
 
 # use newer NodeJS version
-RUN curl -sL deb.nodesource.com/setup_12.x | bash -
+RUN curl -sL deb.nodesource.com/setup_20.x | bash -
 
 # update the package sources
 RUN apt-get update -qq && apt-get upgrade -qq


### PR DESCRIPTION
from https://docs.cypress.io/app/get-started/install-cypress
> Cypress deprecated the use of Node.js 16.x in Cypress [13.0.0](https://docs.cypress.io/app/references/changelog#13-0-0). We recommend that users update to at least Node.js 18.x. 

for https://github.com/joomla/joomla-cms/pull/44675