### PR TITLE
Support https in cypress image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update
 
 # we use the enviroment variable to stop debconf from asking questions..
 RUN DEBIAN_FRONTEND='noninteractive' apt-get install -y apache2 \
-    php7.2  php7.2-cli php7.2-curl php7.2-gd php7.2-mysql php7.2-zip php7.2-xml php7.2-ldap php7.2-mbstring libapache2-mod-php7.2 php7.2-pgsql \
+    php7.2 php7.2-cli php7.2-curl php7.2-gd php7.2-mysql php7.2-zip php7.2-xml php7.2-ldap php7.2-mbstring libapache2-mod-php7.2 php7.2-pgsql \
     curl wget unzip git netcat rsync
 
 # Remove unneded library which leads to an error in cypress
@@ -33,8 +33,16 @@ RUN apt-get clean # && rm -rf /var/lib/apt/lists/*
 # Create testing directory
 RUN mkdir -p /tests/www
 
+# Create certificates
+RUN mkdir /tests/keys
+RUN sudo openssl req -new -newkey rsa:4096 -nodes -keyout /tests/keys/server.key -out /tests/keys/server.csr -subj "/CN=localhost"
+RUN sudo openssl x509 -req -days 365 -in /tests/keys/server.csr -signkey /tests/keys/server.key -out /tests/keys/server.crt
+
 # Apache site conf
 ADD config/000-default.conf /etc/apache2/sites-available/000-default.conf
+
+# Enable Apache SSL module
+RUN a2enmod ssl
 
 # clean up tmp files (we don't need them for the image)
 RUN rm -rf /tmp/* /var/tmp/*

--- a/README.MD
+++ b/README.MD
@@ -1,24 +1,15 @@
 # Docker Systemtest image
 
-Docker with LAMP setup, firefox, chrome and other tools for system tests with codeception.
-
-Based on docker Ubuntu 16.04 image
+Docker with Apache setup for system tests with cypress. Based on docker [cypress included](https://github.com/cypress-io/cypress-docker-images/tree/master/included) image.
 
 Current image can also be found at dockerhub:
 
 https://hub.docker.com/r/joomlaprojects/docker-images
 
-`docker pull joomlaprojects/docker-images:systemtests`
+`docker pull joomlaprojects/docker-images:cypress`
 
 ## Included software
 
-* Apache 2.4
-* MySQL 5.7
-* PHP 7
+* Apache 2.4 with https support
+* PHP 
 * Composer (System wide)
-
-### GUI Software
-
-* Firefox
-* Latest Google Chrome
-* Fluxbox and Xvfb (to run selenium tests)

--- a/config/000-default.conf
+++ b/config/000-default.conf
@@ -14,6 +14,17 @@
 	CustomLog ${APACHE_LOG_DIR}/access.log combined
 </VirtualHost>
 
+<VirtualHost *:443>
+    SSLEngine On
+    SSLCertificateFile /tests/keys/server.crt
+    SSLCertificateKeyFile /tests/keys/server.key
+
+    DocumentRoot /tests/www
+
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+</VirtualHost>
+
 <Directory /tests/www/>
   Options Indexes FollowSymLinks
   AllowOverride All


### PR DESCRIPTION
Enables 443 port in apache for https tests. Additionally it does a cleanup of the README file as it still contains the information from the codeception area.