### PR TITLE
Sign m3 remove anyway

### DIFF
--- a/sign.sh
+++ b/sign.sh
@@ -336,10 +336,6 @@ elif [[ $TUF_PARAMS = "update-timestamp" ]]; then
     -v "$(pwd)/updates:/go" ${DOCKER_IMAGE} "${TUF_PARAMS}"
   cleanupdocker
 elif [[ $TUF_PARAMS = "clean-docker" ]]; then
-  if [ ! -d "$SIGNER_DIR/updates/.git" ]; then
-    echo "Error $SIGNER_DIR/updates/.git doesn't exists."
-    exit 1
-  fi
   rm -rf "$SIGNER_DIR/updates"
   mkdir "$SIGNER_DIR/updates"
   docker run --rm \


### PR DESCRIPTION
Using `sign.sh` with `m3 clean docker environment` was however failing for me with:
```
Error .../docker-images/updates/.git doesn't exist.
```
After reviewing the source code, I worked around it by `mkdir updates/.git`. However, as the `updates` directory is removed recursively in the next step, does the check serve any purpose? If not, I have removed it.